### PR TITLE
Feature/custom draggable builders

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.0-dev.9"
+    version: "5.0.0-dev.10"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/utils/definitions.dart
+++ b/lib/utils/definitions.dart
@@ -28,3 +28,11 @@ typedef OnCreatedFunction = void Function(
 typedef OnDragUpdateFunction = Function(
   DragUpdateDetails details,
 );
+
+typedef CustomDraggableBuilder<T extends Draggable<T>> = T Function(
+  VoidCallback internalOnDragStarted,
+  void Function(Offset offset) internalOnDragCanceled,
+  bool dragging,
+  Widget feedback,
+  Widget child,
+);

--- a/lib/widgets/reorderable_builder.dart
+++ b/lib/widgets/reorderable_builder.dart
@@ -5,6 +5,7 @@ import 'package:flutter_reorderable_grid_view/controller/reorderable_drag_and_dr
 import 'package:flutter_reorderable_grid_view/controller/reorderable_item_builder_controller.dart';
 import 'package:flutter_reorderable_grid_view/entities/released_reorderable_entity.dart';
 import 'package:flutter_reorderable_grid_view/entities/reorderable_entity.dart';
+import 'package:flutter_reorderable_grid_view/utils/definitions.dart';
 import 'package:flutter_reorderable_grid_view/widgets/reorderable_animated_opcacity.dart';
 import 'package:flutter_reorderable_grid_view/widgets/reorderable_animated_positioned.dart';
 import 'package:flutter_reorderable_grid_view/widgets/reorderable_animated_released_container.dart';
@@ -153,9 +154,13 @@ class ReorderableBuilder extends StatefulWidget {
   /// and to your [GridView].
   final ScrollController? scrollController;
 
+  //A builder to create customized draggables
+  final CustomDraggableBuilder? customDraggableBuilder;
+
   const ReorderableBuilder({
     required this.children,
     required this.builder,
+    this.customDraggableBuilder,
     this.scrollController,
     this.onReorder,
     this.lockedIndices = const [],
@@ -181,6 +186,7 @@ class ReorderableBuilder extends StatefulWidget {
   // Todo: werte eher oben definieren und hier wiederverwenden
   const ReorderableBuilder.builder({
     required this.childBuilder,
+    this.customDraggableBuilder,
     this.scrollController,
     this.onReorder,
     this.lockedIndices = const [],
@@ -360,6 +366,7 @@ class _ReorderableBuilderState extends State<ReorderableBuilder>
             releasedChildDuration: widget.releasedChildDuration,
             reorderableEntity: reorderableEntity,
             child: ReorderableDraggable(
+              customDraggableBuilder: widget.customDraggableBuilder,
               reorderableEntity: reorderableEntity,
               enableDraggable: widget.enableDraggable && isDraggable,
               currentDraggedEntity: currentDraggedEntity,

--- a/lib/widgets/reorderable_draggable.dart
+++ b/lib/widgets/reorderable_draggable.dart
@@ -27,6 +27,8 @@ class ReorderableDraggable extends StatefulWidget {
 
   final ReorderableEntity? currentDraggedEntity;
 
+  final CustomDraggableBuilder? customDraggableBuilder;
+
   const ReorderableDraggable({
     required this.child,
     required this.reorderableEntity,
@@ -38,6 +40,7 @@ class ReorderableDraggable extends StatefulWidget {
     required this.onDragCanceled,
     required this.currentDraggedEntity,
     this.dragChildBoxDecoration,
+    this.customDraggableBuilder,
     Key? key,
   }) : super(key: key);
 
@@ -117,6 +120,15 @@ class _ReorderableDraggableState extends State<ReorderableDraggable>
     );
     final data = _getData();
 
+    if (widget.customDraggableBuilder != null) {
+      return widget.customDraggableBuilder!.call(
+        _handleDragStarted,
+        _handleDragEnd,
+        !visible,
+        feedback,
+        child,
+      );
+    }
     if (!widget.enableDraggable) {
       return child;
     } else if (widget.enableLongPress) {


### PR DESCRIPTION
Hi there,

thank you for this great package!

For my project I needed more customising options for the draggables (e.g. rootOverlay, custom dragAnchors, access to all callbacks) and so I came up with the idea of implementing a customDraggablesBuilder. The pull request is intended more as a basis for discussion than as an actual implementation. I think there is still a lot to optimise. But what do you think of the idea? It's a bit ugly that the user now has to add the package-relevant callbacks themselves. As an alternative, I could imagine that draggables are actually passed, but these only act as data containers and everything is put together again in the reorderable_draggable.dart - analogue to the current implementation of CustomDraggables.

Cheers,
Jesper