### PR TITLE
fix assert onReorderPositions for builder

### DIFF
--- a/lib/widgets/reorderable_builder.dart
+++ b/lib/widgets/reorderable_builder.dart
@@ -264,7 +264,9 @@ class ReorderableBuilder<T> extends StatefulWidget {
     this.onDragEnd,
     this.onUpdatedDraggedChild,
     Key? key,
-  })  : assert((enableDraggable && onReorder != null) || !enableDraggable),
+  })  : assert((enableDraggable &&
+                (onReorder != null || onReorderPositions != null)) ||
+            !enableDraggable),
         children = null,
         builder = null,
         super(key: key);

--- a/test/widgets/reorderable_builder_widget_test.dart
+++ b/test/widgets/reorderable_builder_widget_test.dart
@@ -11,6 +11,7 @@ void main() {
       WidgetTester tester, {
       bool enableDraggable = true,
       OnReorderCallback? onReorder,
+      OnReorderPositions? onReorderPositions,
     }) async =>
         tester.pumpWidget(
           MaterialApp(
@@ -18,10 +19,15 @@ void main() {
               body: ReorderableBuilder.builder(
                 itemCount: 1,
                 childBuilder: (itemBuilder) {
-                  return itemBuilder(const Placeholder(), 0);
+                  return itemBuilder(
+                      const Placeholder(
+                        key: ValueKey('0'),
+                      ),
+                      0);
                 },
                 enableDraggable: enableDraggable,
                 onReorder: onReorder,
+                onReorderPositions: onReorderPositions,
               ),
             ),
           ),
@@ -34,6 +40,20 @@ void main() {
       expect(
         () => pumpWidget(tester, enableDraggable: true, onReorder: null),
         throwsAssertionError,
+      );
+    });
+
+    testWidgets(
+        "GIVEN enableDraggable = true and onReorder = null and onReorderPositions != null "
+        "WHEN pumping [ReorderableBuilder.builder] "
+        "THEN should return normally", (WidgetTester tester) async {
+      expect(
+        () => pumpWidget(
+          tester,
+          enableDraggable: true,
+          onReorderPositions: (p0) {},
+        ),
+        returnsNormally,
       );
     });
 


### PR DESCRIPTION
This is a follow up for PR #153 where I forgot to adjust the assert for the `builder` constructor.